### PR TITLE
emit LVL-DRAG-END on drop

### DIFF
--- a/script/lvl-drag-drop.js
+++ b/script/lvl-drag-drop.js
@@ -125,6 +125,7 @@ module.directive('lvlDropTarget', ['$rootScope', 'uuid', function($rootScope, uu
                 }
 
                 var data = e.dataTransfer.getData('text');
+                $rootScope.$emit('LVL-DRAG-END');
                 scope.onDrop({dragEl: data, dropEl: id, event: e});
             };
 


### PR DESCRIPTION
Because `dragend` is not fired sometimes in Firefox when there is a drop listener.